### PR TITLE
Issue 36 cone lost recovery

### DIFF
--- a/config/navigator-mock.yaml
+++ b/config/navigator-mock.yaml
@@ -89,3 +89,10 @@ horz_fov: 70.0
 
 # The horizontal field-of-view of the camera, in pixels.
 horz_pixels: 640
+
+# The number of consecutive cone location messages to receive
+# without a cone detection while driving in manual to a cone
+# before we go into recovery mode. (Equals the number of
+# video frames, if the cone detector is sending one message
+# per frame.)
+cone_lost_limit: 15

--- a/config/navigator.yaml
+++ b/config/navigator.yaml
@@ -88,3 +88,10 @@ horz_fov: 70.0
 
 # The horizontal field-of-view of the camera, in pixels.
 horz_pixels: 640
+
+# The number of consecutive cone location messages to receive
+# without a cone detection while driving in manual to a cone
+# before we go into recovery mode. (Equals the number of
+# video frames, if the cone detector is sending one message
+# per frame.)
+cone_lost_limit: 15

--- a/launch/mock_mission.launch
+++ b/launch/mock_mission.launch
@@ -5,6 +5,7 @@
   <arg name="view_mission" default="true" />
   <arg name="start_rviz" default="false" />
   <arg name="detect_cones" default="true" />
+  <arg name="cone_detection_patterns" default="[]" />
 
   <include file="$(find mavros)/launch/apm.launch">
     <!-- this must match the UP port-baud rate connected to Pixhawk -->
@@ -25,6 +26,8 @@
   <node name="mock_cone_detector" pkg="robo_magellan"
         type="mock_cone_detector" output="$(arg log_output)">
     <param name="~detect_cones" value="$(arg detect_cones)" />
+    <param name="~cone_detection_patterns"
+           value="$(arg cone_detection_patterns)" />
     <remap from="~waypoints/local" to="/robo_magellan/waypoints/local" />
     <remap from="~cone_locations" to="/cone_finder/locations" />
   </node>

--- a/scripts/mock_cone_detector
+++ b/scripts/mock_cone_detector
@@ -119,7 +119,7 @@ class MockConeDetector:
 
         # If we have exhausted the count for the current position, move
         # to the next position.
-        if count > pattern[position]:
+        if count >= pattern[position]:
             position += 1
             count = 0
             rospy.loginfo('Moving to pattern %d for cone %d',

--- a/scripts/mock_cone_detector
+++ b/scripts/mock_cone_detector
@@ -16,7 +16,7 @@ class Topics:
     LOCAL_POSITION = '/mavros/local_position/pose'
     CONE_LOCATIONS = '~cone_locations'
     LOCAL_WAYPOINTS = '~waypoints/local'
-    
+
 class MockConeDetector:
 
     def run(self):
@@ -26,7 +26,13 @@ class MockConeDetector:
         self.camera_horz_fov = rospy.get_param('~horz_fov', 70.0) / 180.0 * pi
         self.camera_horz_pixels = rospy.get_param('~horz_pixels', 640)
         self.detect_cones = rospy.get_param("~detect_cones", True)
-        
+
+        self.cone_detection_patterns = eval(rospy.get_param(
+            '~cone_detection_patterns', "[]"))
+        self.detection_positions = [0 for p in self.cone_detection_patterns]
+        self.detection_counts = [0 for p in self.cone_detection_patterns]
+        rospy.loginfo('%d cone patterns', len(self.cone_detection_patterns))
+
         self.waypoint_list = LocalWaypointList()
         self.waypoint_list.waypoints = []
 
@@ -57,12 +63,12 @@ class MockConeDetector:
         # heading angle.
         fov_dist = self.camera_horz_pixels/2 / tan(self.camera_horz_fov/2)
 
-        i = 0
+        cone_index = 0
         for wp in self.waypoint_list.waypoints:
             # Skip waypoints that are not cones.
             if wp.point.z < 1000:
                 continue
-            
+
             # Cone location.
             xc, yc = wp.point.x, wp.point.y
             d = sqrt((xc-xr)**2 + (yc-yr)**2)
@@ -82,22 +88,56 @@ class MockConeDetector:
                 pose.y = 0 # Just put all cones in the middle, vertically.
                 pose.z = 0 # Assume minimum possible depth is not available.
                 pose.w, pose.h, pose.area = self.get_cone_area(d)
-                cone_poses.append(pose)
 
-                if self.detect_cones:
+                if self.detect_cones and self.is_cone_detected(cone_index):
+                    cone_poses.append(pose)
                     rospy.loginfo('[Detector] cone %d: d=%f heading=%f x=%d',
-                                  i, d, heading*180/pi, pose.x)
+                                  cone_index, d, heading*180/pi, pose.x)
 
-            i += 1
-
-        # Ignore all cone positions if we should not detect them.
-        if not self.detect_cones:
-            cone_poses = []
+            cone_index += 1
 
         msg = location_data()
         msg.header.stamp = rospy.Time.now()
         msg.poses = cone_poses
         self.cone_pub.publish(msg)
+
+    def is_cone_detected(self, cone_index):
+        # If we don't have a detection pattern for the cone, we always
+        # see it.
+        if cone_index >= len(self.cone_detection_patterns):
+            rospy.loginfo('No detection pattern for cone %d', cone_index)
+            return True
+
+        pattern = self.cone_detection_patterns[cone_index]
+        position = self.detection_positions[cone_index]
+        count = self.detection_counts[cone_index]
+
+        # If we have exhausted the pattern, we always see the cone.
+        if position >= len(pattern):
+            rospy.loginfo('No more patterns for cone %d', cone_index)
+            return True
+
+        # If we have exhausted the count for the current position, move
+        # to the next position.
+        if count > pattern[position]:
+            position += 1
+            count = 0
+            rospy.loginfo('Moving to pattern %d for cone %d',
+                          position, cone_index)
+
+        count += 1
+        # We detect the cone at even numbered positions in the pattern or
+        # if we have exhausted the pattern.
+        detected = (position >= len(pattern)) or (position%2 == 0)
+        rospy.loginfo('Cone detection: cone=%d position=%d count=%d detect=%s',
+                      cone_index, position, count, detected)
+
+        # Update count and position.
+        self.detection_positions[cone_index] = position
+        self.detection_counts[cone_index] = count
+
+        return detected
+
 
     def get_cone_area(self, d):
         # Area should be proportional to the square of distance.

--- a/scripts/navigator
+++ b/scripts/navigator
@@ -97,6 +97,7 @@ class Navigator:
         self.map_waypoint_list = None
         self.target_heading = None
         self.robot_pose = PoseStamped()
+        self.cone_lost_count = 0
 
         rospy.init_node('navigator')
 
@@ -147,6 +148,8 @@ class Navigator:
 
         self.camera_horz_fov = rospy.get_param('~horz_fov', 70.0) / 180.0 * pi
         self.camera_horz_pixels = rospy.get_param('~horz_pixels', 640)
+
+        self.cone_lost_limit = rospy.get_param('~cone_lost_limit', 15)
 
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
@@ -304,7 +307,6 @@ class Navigator:
 
         if self.state is States.DRIVING_TO_CONE and touching:
             self.show_event('on_touch', touching)
-            self.cancel_timer()
             self.set_manual_speed(0, 0)
             if self.cone_wp_index == len(self.waypoint_list.waypoints) - 1:
                 self.set_mode(Modes.HOLD)
@@ -341,8 +343,14 @@ class Navigator:
             self.begin_driving_to_cone()
         elif self.state is States.DRIVING_TO_CONE \
              and len(cone_locations.poses) > 0:
+            self.cone_lost_count = 0
             self.show_event('on_cone_locations', len(cone_locations.poses))
             self.drive_to_cone(cone_locations.poses[0])
+        elif self.state is States.DRIVING_TO_CONE:
+            self.cone_lost_count += 1
+            if self.cone_lost_count > self.cone_lost_limit:
+                # Lost cone, must recover.
+                self.begin_circling_back()
         elif self.state is States.CIRCLING_FORWARD:
             robot_heading = self.pose_heading(self.robot_pose.pose)
             diff = self.normalize_angle(self.target_heading - robot_heading)
@@ -376,7 +384,7 @@ class Navigator:
         else:
             self.set_mode(Modes.GUIDED)
             self.drive_to_cone(cone_locations.poses[0])
-            self.begin_state(States.DRIVING_TO_CONE)
+        self.begin_state(States.DRIVING_TO_CONE)
 
     def drive_to_cone(self, cone_pose):
         # A pseudo-distance used to determine the pixel width of a cone


### PR DESCRIPTION
Added code to recover from losing the cone while driving to it. Keeping track of a count of missed cone detections. If the number of consecutive misses exceeds a threshold, go into the circling recovery mode.